### PR TITLE
model_path -> model in choose_calculator

### DIFF
--- a/pack_mm/core/core.py
+++ b/pack_mm/core/core.py
@@ -301,7 +301,7 @@ def pack_molecules(
 
     calc = choose_calculator(
         arch=arch,
-        model_path=model,
+        model=model,
         device=device,
         dispersion=dispersion,
     )


### PR DESCRIPTION
This option was changed following https://github.com/stfc/janus-core/pull/640